### PR TITLE
Remove relative reference when it does not work

### DIFF
--- a/docs/mde_customizeObjects.rst
+++ b/docs/mde_customizeObjects.rst
@@ -171,7 +171,7 @@ You can specify the different types like:
               Value=""
               Visible="true" />
 
- `ComboBox` with values from ontology (OMERO.insight version >= |insight_version|)::
+ `ComboBox` with values from ontology (OMERO.insight version >= 5.5.15)::
 
     <TagData DefaultValues=""
              Name="Tag of Type ComboBox val from ontology href"
@@ -182,7 +182,7 @@ You can specify the different types like:
         <Ontology URL_restapi="http://data.bioontology.org" Acronym="BAO" ID_href="http://www.bioassayontology.org/bao#BAO_0150008" />
     </TagData>
 
- `CheckComboBox` for multiple selection (OMERO.insight version >= |insight_version|)::
+ `CheckComboBox` for multiple selection (OMERO.insight version >= 5.5.15)::
 
      <TagData DefaultValues="Value1,Value2,Value3"
               Name="Tag of Type CheckComboBox"

--- a/docs/mde_customizeView.rst
+++ b/docs/mde_customizeView.rst
@@ -5,7 +5,7 @@ Description
 -----------
 
 You can generate a filter view of the sets of objects. Also you can hide properties for objects and change the default unit.
-You can mark fields as required to restrict your input forms to objects with required metadata (OMERO.insight version >= |insight_version|).
+You can mark fields as required to restrict your input forms to objects with required metadata (OMERO.insight version >= 5.5.15).
 We will show in this section how to create a new setup and how to generate customized input forms of available objects in this setup.
 
 Step-by-Step
@@ -55,7 +55,7 @@ Step-by-Step
 
 |mde_customizeView_Customize|
 
-You can mark any field as required by adding ``Required = "true"`` as an attribute of ``TagDataProp`` (OMERO.insight version >= |insight_version|).
+You can mark any field as required by adding ``Required = "true"`` as an attribute of ``TagDataProp`` (OMERO.insight version >= 5.5.15).
 By selecting |mde_required_btn|, you can restrict the displayed objects of the selected setup to those that contain at least one required metadata field::
 
             <MDEObjects>


### PR DESCRIPTION
Removing the variable ``insight_version`` in 4 places where it does not resolve. 
Interestingly:

  - the variable does resolve in local build of this repo
  - the variable does not resolve when building the ``omero-guides`` repo (and ``make clean`` gives warns)
  - the variable does not resolve on for example [this page of the production guides](https://omero-guides.readthedocs.io/en/latest/mde/docs/mde_customizeView.html?highlight=insight_version#description)
  - the variable does resolve in some cases, for example https://omero-guides.readthedocs.io/projects/omero-guide-mde/en/latest/mde_customizeObjects.html?highlight=5.5.15#type-of-input-fields
 
This is also motivated by https://github.com/ome/omero-guides/issues/56

cc @jburel @joshmoore 